### PR TITLE
[CI] node_modules の cache の設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,22 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x
+
       - name: install
         run: npm i
+
       - name: Run eslint
         run: npm run fix
+
       - name: Run Prettier
         run: |
           npx prettier --write ${FILE_PATTERN}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,4 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v3.0.0
         with:
           commit_message: Apply Prettier Change
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,10 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: actions/cache@v2
+      - uses: actions/setup-node@v2
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
+          node-version: '14'
+          cache: npm
 
       - name: install
         run: npm i


### PR DESCRIPTION
現在，CI が実行されるたびに package をインストールしていたが，キャッシュを有効にすることで実行時間の短縮を目指した．

[キャッシュ有効前](https://github.com/HARUKINEMA/ki-wi/runs/3906253135?check_suite_focus=true) => 64s
[キャッシュ有効後](https://github.com/HARUKINEMA/ki-wi/runs/3906316291?check_suite_focus=true) => 52s